### PR TITLE
Improve Input Handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,10 +130,15 @@ pub fn run(
         let message = midi_in.message.clone();
         thread::spawn(move || {
             loop {
-                let r = run_consumer.lock().unwrap();
-                let mut r = message.1.wait(r).unwrap();
+                let queue = message.0.lock().unwrap();
+                let mut queue = message
+                    .1
+                    .wait_while(queue, |q| q.is_empty())
+                    .unwrap()
+                    .drain(..)
+                    .collect();
+                let mut r = run_consumer.lock().unwrap();
                 let (ref mut conductor, ref mut controller, ref mut ctx) = *r;
-                let mut queue = message.0.lock().unwrap();
                 ctx.handle_input(conductor, controller, &mut queue);
             }
         });


### PR DESCRIPTION
The current input logic in (std) mseq is flawed.

We now wait for any element in the queue, drain it, and release the lock immediately, before locking the conductor, controller, and context. This prevents any possible deadlock (we never have 2 locks at the same time), and decreases the time spent with the queue locked.

We also add a wait_while for the queue lock because it can trigger spuriously.